### PR TITLE
Add verbosity configuration for HMD pose invalid handler

### DIFF
--- a/p3dopenvr/p3dopenvr.py
+++ b/p3dopenvr/p3dopenvr.py
@@ -291,7 +291,8 @@ class P3DOpenVR():
         self.poll_events()
         hmd_pose = self.poses[openvr.k_unTrackedDeviceIndex_Hmd]
         if not hmd_pose.bPoseIsValid:
-            print("HMD pose is not valid")
+            if verbose:
+                print("HMD pose is not valid")
             return task.cont
         self.update_hmd(hmd_pose)
         self.update_tracked_devices()


### PR DESCRIPTION
This PR adds verbosity configuration for the print statement on line 295, which is especially annoying if you forwarded STDOUT to error boxes :P